### PR TITLE
Apply filter to allow SLCB in the backend.

### DIFF
--- a/super-light-cache-buster.php
+++ b/super-light-cache-buster.php
@@ -430,7 +430,9 @@ $slcb_fields = new Super_Light_Cache_Buster();
 
 $randomizer_control = get_option( 'slcb_plugin_state', $slcb_fields->get_slcb_fields( 0 ) );
 
-if ( ! is_admin() && 'option1' === $randomizer_control[0] ) {
+$allow_in_backend = apply_filters( 'slcb_allow_in_backend', false );
+
+if ( ! is_admin() || $allow_in_backend && 'option1' === $randomizer_control[0] ) {
 
 	// Randomize asset version for styles.
 	add_filter( 'style_loader_src', 'slcb_randomize_ver', 9999 );


### PR DESCRIPTION
Enabling the plugin to work in the backend causes an error:

> The stylesheet https://example.local/wp-admin/index.php?ver=469947700 was not loaded because its MIME type, “text/html”, is not “text/css”.

Apparently, the [script loader filter](https://developer.wordpress.org/reference/hooks/script_loader_src/) applies to PHP scripts when the filter is used in the admin dashboard.

Instead of allowing the plugin to operate in the backend by default, I've applied a filter (`slcb_allow_in_backend`) that can be used to allow SLCB to run in the dashboard. Its value is false by default.

It can be used like so, for example:

```
add_filter( 'slcb_allow_in_backend', 'allow_slcb_in_backend', 10, 0 );

function allow_slcb_in_backend() {
	return true;
}
```